### PR TITLE
Experience refactor

### DIFF
--- a/src/components/TertiaryHeadline.astro
+++ b/src/components/TertiaryHeadline.astro
@@ -1,0 +1,15 @@
+---
+interface Props {
+  text: string;
+}
+
+const { text } = Astro.props;
+---
+
+{
+  text && (
+    <h3 class="font-medium text-md leading-8 text-balance dark:text-orange">
+      {text}
+    </h3>
+  )
+}

--- a/src/components/about/AboutSection.astro
+++ b/src/components/about/AboutSection.astro
@@ -1,5 +1,6 @@
 ---
 import Section from "@components/Section.astro";
+import TertiaryHeadline from "@components/TertiaryHeadline.astro";
 
 interface Props {
   headline: string;
@@ -11,13 +12,7 @@ const { headline, secondaryHeadline } = Astro.props;
 
 <Section headline={headline}>
   <div class="grid gap-4 mt-8">
-    {
-      secondaryHeadline && (
-        <h3 class="font-medium text-md leading-8 text-balance dark:text-orange">
-          {secondaryHeadline}
-        </h3>
-      )
-    }
+    {secondaryHeadline && <TertiaryHeadline text={secondaryHeadline} />}
     <slot />
   </div>
 </Section>

--- a/src/components/about/Experience.astro
+++ b/src/components/about/Experience.astro
@@ -4,27 +4,57 @@ import DateItem from "@components/about/DateItem.astro";
 
 const experienceItems = [
   {
-    position: "Senior Front-End Developer",
-    startDate: "2021-10",
-    endDate: "2025-01",
+    company: "Sullivan",
+    positions: [
+      {
+        position: "Front-End Developer",
+        startDate: "2025-01",
+        endDate: "",
+      },
+    ],
   },
-  { position: "Front-End Developer", startDate: "2015-12", endDate: "2021-10" },
-  { position: "Intern", startDate: "2015-09", endDate: "2015-12" },
+  {
+    company: "Elegant Seagulls",
+    positions: [
+      {
+        position: "Senior Front-End Developer",
+        startDate: "2021-10",
+        endDate: "2025-01",
+      },
+      {
+        position: "Front-End Developer",
+        startDate: "2015-12",
+        endDate: "2021-10",
+      },
+      { position: "Intern", startDate: "2015-09", endDate: "2015-12" },
+    ],
+  },
 ];
 ---
 
-<AboutSection headline="Experience" secondaryHeadline="Elegant Seagulls">
+<AboutSection headline="Experience">
   {
     experienceItems?.length && (
-      <ol class="grid gap-2">
+      <ol class="grid gap-5">
         {experienceItems.map((item) => (
           <li>
-            <DateItem
-              type="experience"
-              title={item.position}
-              startDate={item.startDate}
-              endDate={item.endDate}
-            />
+            <h3 class="front-medium text-md leading-8 text-balance dark:text-orange">
+              {item.company}
+            </h3>
+            {item.positions?.length && (
+              <ol class="grid gap-2 mt-2">
+                {item.positions.map((position) => (
+                  <li>
+                    <DateItem
+                      type="Experience"
+                      title={position.position}
+                      startDate={position.startDate}
+                      endDate={position.endDate}
+                    />
+                  </li>
+                ))}
+              </ol>
+            )}
           </li>
         ))}
       </ol>

--- a/src/components/about/Experience.astro
+++ b/src/components/about/Experience.astro
@@ -5,22 +5,12 @@ import TertiaryHeadline from "@components/TertiaryHeadline.astro";
 
 const experienceItems = [
   {
-    company: "Sullivan",
-    positions: [
-      {
-        position: "Front-End Developer",
-        startDate: "2025-01",
-        endDate: "",
-      },
-    ],
-  },
-  {
     company: "Elegant Seagulls",
     positions: [
       {
         position: "Senior Front-End Developer",
         startDate: "2021-10",
-        endDate: "2025-01",
+        endDate: "",
       },
       {
         position: "Front-End Developer",
@@ -28,6 +18,16 @@ const experienceItems = [
         endDate: "2021-10",
       },
       { position: "Intern", startDate: "2015-09", endDate: "2015-12" },
+    ],
+  },
+  {
+    company: "DeVos Art Museum",
+    positions: [
+      {
+        position: "Gallery Assistant",
+        startDate: "2015-05",
+        endDate: "2015-12",
+      },
     ],
   },
 ];

--- a/src/components/about/Experience.astro
+++ b/src/components/about/Experience.astro
@@ -1,6 +1,7 @@
 ---
 import AboutSection from "@components/about/AboutSection.astro";
 import DateItem from "@components/about/DateItem.astro";
+import TertiaryHeadline from "@components/TertiaryHeadline.astro";
 
 const experienceItems = [
   {
@@ -38,9 +39,7 @@ const experienceItems = [
       <ol class="grid gap-5">
         {experienceItems.map((item) => (
           <li>
-            <h3 class="front-medium text-md leading-8 text-balance dark:text-orange">
-              {item.company}
-            </h3>
+            <TertiaryHeadline text={item.company} />
             {item.positions?.length && (
               <ol class="grid gap-2 mt-2">
                 {item.positions.map((position) => (


### PR DESCRIPTION
This pull request includes several changes to the `src/components` directory, primarily focusing on the introduction of a new `TertiaryHeadline` component and its integration into existing components. The most important changes include creating the `TertiaryHeadline` component, modifying the `AboutSection` and `Experience` components to use the new `TertiaryHeadline` component, and updating the experience items structure.

### Introduction of `TertiaryHeadline` component:
* [`src/components/TertiaryHeadline.astro`](diffhunk://#diff-553556c5fbd0e414cad88c3d429948aee65a77148103c6ad64156816418e09bdR1-R15): Created a new `TertiaryHeadline` component that accepts a `text` prop and renders it within an `<h3>` element.

### Integration of `TertiaryHeadline` component:
* [`src/components/about/AboutSection.astro`](diffhunk://#diff-3f786b0d048dc8a4e3060ae74136c1b5ba8d7f36e8cf40a4e0be4c98a4768878R3): Imported the `TertiaryHeadline` component and replaced the inline `<h3>` element for `secondaryHeadline` with the `TertiaryHeadline` component. [[1]](diffhunk://#diff-3f786b0d048dc8a4e3060ae74136c1b5ba8d7f36e8cf40a4e0be4c98a4768878R3) [[2]](diffhunk://#diff-3f786b0d048dc8a4e3060ae74136c1b5ba8d7f36e8cf40a4e0be4c98a4768878L14-R15)
* [`src/components/about/Experience.astro`](diffhunk://#diff-88cf14d3ca280c90ff91d14b48101aeef081455d41d7b8540114267b34cfe661R4-R59): Imported the `TertiaryHeadline` component and used it to display the company names within the experience items list.

### Updates to experience items structure:
* [`src/components/about/Experience.astro`](diffhunk://#diff-88cf14d3ca280c90ff91d14b48101aeef081455d41d7b8540114267b34cfe661R4-R59): Updated the structure of `experienceItems` to group positions by company and adjusted the rendering logic accordingly.