### PR TITLE
Refactor formatDate function

### DIFF
--- a/src/components/about/DateItem.astro
+++ b/src/components/about/DateItem.astro
@@ -1,4 +1,6 @@
 ---
+import { formatDate } from "@utils/date";
+
 interface Props {
   type: string;
   title: string;
@@ -7,21 +9,6 @@ interface Props {
 }
 
 const { type, title, startDate, endDate } = Astro.props;
-
-/**
- * Format a date string as a human-readable date.
- * @param {string} dateString - The date string to format.
- * @returns {string} The formatted date string.
- */
-const formatDate = (dateString: string | null | undefined): string | null => {
-  if (!dateString) return null;
-
-  const [year, month] = dateString.split("-");
-  if (!year || !month) return null; // Validate inputs
-
-  const date = new Date(Number(year), Number(month) - 1); // Month is 0-indexed
-  return new Intl.DateTimeFormat("en-US", { year: "numeric", month: "long" }).format(date);
-};
 ---
 
 <div

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,19 @@
+/**
+ * Format a date string as a human-readable date.
+ * @param {string} dateString - The date string to format.
+ * @returns {string} The formatted date string.
+ */
+export const formatDate = (
+  dateString: string | null | undefined
+): string | null => {
+  if (!dateString) return null;
+
+  const [year, month] = dateString.split("-");
+  if (!year || !month) return null; // Validate inputs
+
+  const date = new Date(Number(year), Number(month) - 1); // Month is 0-indexed
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "long",
+  }).format(date);
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "baseUrl": ".",
     "jsx": "react-jsx",
     "paths": {
+      "@utils/*": ["src/utils/*"],
       "@images/*": ["src/assets/images/*"],
       "@components/*": ["src/components/*"],
       "@layouts/*": ["src/layouts/*"]


### PR DESCRIPTION
This pull request includes changes to refactor the `formatDate` function by moving it from `src/components/about/DateItem.astro` to `src/utils/date.ts` for better code organization and reuse.

Code refactoring:

* [`src/components/about/DateItem.astro`](diffhunk://#diff-71032c990a4402c885a72caa1c52adf3d10ba821e5e359b15b03c322ea0bfd27R2-R3): Removed the `formatDate` function and imported it from `@utils/date` instead. [[1]](diffhunk://#diff-71032c990a4402c885a72caa1c52adf3d10ba821e5e359b15b03c322ea0bfd27R2-R3) [[2]](diffhunk://#diff-71032c990a4402c885a72caa1c52adf3d10ba821e5e359b15b03c322ea0bfd27L10-L24)
* [`src/utils/date.ts`](diffhunk://#diff-10baaa420455f75556cb3f2ab221bd12171abf0c582942a5b0201fd86b784c8aR1-R19): Added the `formatDate` function to this utility file.