### PR TITLE
Add Monkeytype to Social List and Sort Social List Alphabetically

### DIFF
--- a/src/components/SocialLinks.astro
+++ b/src/components/SocialLinks.astro
@@ -20,11 +20,13 @@ const links = [
   links?.length && (
     <Section headline="Elsewhere" topSpacing>
       <ul class="flex gap-2 mt-8">
-        {links.map((link) => (
-          <li>
-            <NavLink href={link.href}>{link.label}</NavLink>
-          </li>
-        ))}
+        {links
+          .sort((a, b) => a.label.localeCompare(b.label))
+          .map((link) => (
+            <li>
+              <NavLink href={link.href}>{link.label}</NavLink>
+            </li>
+          ))}
       </ul>
     </Section>
   )

--- a/src/components/SocialLinks.astro
+++ b/src/components/SocialLinks.astro
@@ -5,10 +5,13 @@ import NavLink from "@components/NavLink.astro";
 const links = [
   { href: "mailto:jacob@proffer.dev", label: "Email" },
   { href: "https://www.github.com/jacobproffer/", label: "GitHub" },
-  { href: "https://www.dribbble.com/jacobproffer/", label: "Dribbble" },
   {
     href: "https://www.linkedin.com/in/jacob-proffer-a829a892/",
     label: "LinkedIn",
+  },
+  {
+    href: "https://monkeytype.com/profile/jproffer",
+    label: "Monkeytype",
   },
 ];
 ---


### PR DESCRIPTION
This pull request includes changes to the `src/components/SocialLinks.astro` file to update the list of social links and improve their display order. The most important changes include the removal of the Dribbble link, the addition of a Monkeytype link, and the sorting of links alphabetically by their label.

Updates to social links:

* Removed the Dribbble link from the `links` array.
* Added a new Monkeytype link to the `links` array.

Improvements to display order:

* Sorted the social links alphabetically by their label before rendering.