### PR TITLE
Update experience and profile sections

### DIFF
--- a/src/components/about/Experience.astro
+++ b/src/components/about/Experience.astro
@@ -10,7 +10,7 @@ const experienceItems = [
       {
         position: "Senior Front-End Developer",
         startDate: "2021-10",
-        endDate: "",
+        endDate: "2025-01",
       },
       {
         position: "Front-End Developer",

--- a/src/components/about/Profile.astro
+++ b/src/components/about/Profile.astro
@@ -6,11 +6,9 @@ import InlineLink from "@components/InlineLink.astro";
 <AboutSection headline="Profile">
   <div class="grid gap-y-1 max-w-[80ch]">
     <p>
-      I develop fully custom WordPress themes, build enterprise level websites
-      with Next.js, and oversee digital accessibility as a Senior Front-End
-      Developer at <InlineLink href="https://www.elegantseagulls.com/"
-        >Elegant Seagulls</InlineLink
-      > in Marquette, Michigan.
+      I'm a front-end developer based in Marquette, Michigan with over nine
+      years of experience. I specialize in crafting accessible and performant
+      solutions for the web.
     </p>
     <p>
       Currently working with <InlineLink href="https://astro.build/"
@@ -24,7 +22,7 @@ import InlineLink from "@components/InlineLink.astro";
         >write</InlineLink
       >, study <InlineLink href="https://jacobproffer.com/japanese/"
         >Japanese</InlineLink
-      >, and run trails.
+      >, and run the Noquemanon trails.
     </p>
   </div>
 </AboutSection>


### PR DESCRIPTION
This pull request includes updates to the `Experience` and `Profile` sections of the about page to reflect more current information and improve clarity.

Updates to `Experience` section:

* [`src/components/about/Experience.astro`](diffhunk://#diff-88cf14d3ca280c90ff91d14b48101aeef081455d41d7b8540114267b34cfe661L13-R13): Updated the `endDate` for the "Senior Front-End Developer" position to "2025-01".

Updates to `Profile` section:

* [`src/components/about/Profile.astro`](diffhunk://#diff-32783a9a7dbf32dfc3468e2e582aa2aee807a53ce025765b0239d6dbd0ff623bL9-R11): Revised the profile description to provide a more concise overview of the developer's experience and specialization.
* [`src/components/about/Profile.astro`](diffhunk://#diff-32783a9a7dbf32dfc3468e2e582aa2aee807a53ce025765b0239d6dbd0ff623bL27-R25): Updated the description of hobbies to specify running the Noquemanon trails.