### PR TITLE
Update SEO description and improve default image alt text

### DIFF
--- a/src/components/SiteSEO.astro
+++ b/src/components/SiteSEO.astro
@@ -1,6 +1,6 @@
 ---
 import { SEO, type Props as SEOProps } from "astro-seo";
-const defaultImageFile = new URL('/images/social.jpg', Astro.url);
+const defaultImageFile = new URL("/images/social.jpg", Astro.url);
 
 interface Props {
   seo?: SEOProps;
@@ -14,7 +14,8 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
 <SEO
   title={seo?.title}
-  description={seo?.description ?? "Jacob Proffer is a Senior Front-End Developer based in Marquette, Michigan. Currently working at Elegant Seagulls."}
+  description={seo?.description ??
+    "Jacob Proffer is a front-end developer based in Marquette, Michigan with over nine years of experience."}
   canonical={canonicalURL}
   openGraph={{
     basic: {
@@ -26,7 +27,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
     image: {
       url: defaultImageFile.toString(),
       secureUrl: defaultImageFile.toString(),
-      alt: '',
+      alt: "",
       height: 1200,
       width: 800,
     },
@@ -39,7 +40,9 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
       },
       {
         name: "og:description",
-        content: seo?.description ?? "Jacob Proffer is a Senior Front-End Developer based in Marquette, Michigan. Currently working at Elegant Seagulls.",
+        content:
+          seo?.description ??
+          "Jacob Proffer is a front-end developer based in Marquette, Michigan with over nine years of experience.",
       },
       {
         name: "og:site_name",


### PR DESCRIPTION
This pull request includes changes to the `src/components/SiteSEO.astro` file to update the SEO metadata and improve code consistency. The most important changes include updating the default description text and ensuring consistent use of double quotes.

SEO metadata updates:

* Updated the default description text to reflect nine years of experience and removed the specific mention of the current workplace. [[1]](diffhunk://#diff-43eae8286a770c9f2424098731484f4b62f27d842ad4adc664c1bab852bc2422L17-R18) [[2]](diffhunk://#diff-43eae8286a770c9f2424098731484f4b62f27d842ad4adc664c1bab852bc2422L42-R45)

Code consistency improvements:

* Changed single quotes to double quotes for the `defaultImageFile` URL and the `alt` attribute in the Open Graph image metadata. [[1]](diffhunk://#diff-43eae8286a770c9f2424098731484f4b62f27d842ad4adc664c1bab852bc2422L3-R3) [[2]](diffhunk://#diff-43eae8286a770c9f2424098731484f4b62f27d842ad4adc664c1bab852bc2422L29-R30)