### PR TITLE
Add unique ARIA labels to nav elements

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -17,7 +17,7 @@ const links = [
 <footer
   class="p-3 bg-linear-to-t from-dark-blue to-mid-blue border border-black"
 >
-  <nav aria-label="social">
+  <nav aria-label="secondary">
     <ul class="flex gap-4">
       {
         links

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -10,7 +10,7 @@ const links = [
 ];
 ---
 
-<nav aria-label="social">
+<nav aria-label="primary">
   <ul class="flex gap-4">
     {
       links


### PR DESCRIPTION
This pull request includes changes to the `src/components/Footer.astro` and `src/components/Navigation.astro` files to update the `aria-label` attributes for better accessibility.

Accessibility improvements:

* [`src/components/Footer.astro`](diffhunk://#diff-9f7d7eae483a60a6aa76bcb68acc770e441d441ce02d414637694162983e6159L20-R20): Changed `aria-label` from "social" to "secondary" for the footer navigation.
* [`src/components/Navigation.astro`](diffhunk://#diff-ac41776b9c3b4d27fb2b389c1b6bff11ae0e0b742b9913763097a2a89bf8d60eL13-R13): Changed `aria-label` from "social" to "primary" for the main navigation.