### PR TITLE
Add Border to Outer Wrapper and Fix Avatar Background

### DIFF
--- a/src/components/Avatar.astro
+++ b/src/components/Avatar.astro
@@ -4,7 +4,7 @@ import thumbnail from "@images/proffer_jacob.jpg";
 ---
 
 <figure
-  class="bg-dark-blue p-3 border-black border-l-highlight border-t-highlight border"
+  class="bg-linear-to-t from-dark-blue to-mid-blue p-3 border-black border-l-highlight border-t-highlight border"
 >
   <div class="h-full bg-mid-blue p-3 border-black border">
     <div class="relative border-black border max-md:aspect-video">

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -61,7 +61,9 @@ const { pageTitle, pageDescription } = Astro.props;
   </head>
   <body class="mx-auto w-full leading-8 font-normal text-white bg-dark">
     <Container>
-      <div class="grid gap-3 p-3 m-3 bg-light md:gap-6 md:p-6 md:m-6">
+      <div
+        class="grid gap-3 p-3 m-3 bg-light md:gap-6 md:p-6 md:m-6 border border-black border-t-highlight border-l-highlight"
+      >
         <Header />
         <main id="content" transition:name="root" transition:animate="none">
           <slot />


### PR DESCRIPTION
Closes #49 

This pull request includes changes to improve the styling of components in the `src/components` and `src/layouts` directories. The most important changes involve adding gradient backgrounds and border highlights.

Styling improvements:

* [`src/components/Avatar.astro`](diffhunk://#diff-e75c0de83a927f433fb00673e1d0bac746662d0d7c504020cfec3e60d3d37fb6L7-R7): Changed the background class to use a gradient from `dark-blue` to `mid-blue` for a more visually appealing effect.
* [`src/layouts/BaseLayout.astro`](diffhunk://#diff-621c0d4e1d798274214c5a1d9218138167506a88dcdace8c2bb980d6fb10b08bL64-R66): Added border highlights to the container div for better visual separation and emphasis.