### PR TITLE
Refactor components: remove unnecessary border styles for cleaner design

### DIFF
--- a/src/components/AboutSection.astro
+++ b/src/components/AboutSection.astro
@@ -12,9 +12,7 @@ const { secondaryHeadline } = Astro.props;
 
 <Section>
   {secondaryHeadline && <SecondaryHeadline text={secondaryHeadline} />}
-  <div
-    class="grid gap-3 m-3 bg-mid-blue border border-black border-l-highlight border-t-highlight"
-  >
+  <div class="grid gap-3 bg-mid-blue">
     <div class="p-3">
       <slot />
     </div>

--- a/src/components/Avatar.astro
+++ b/src/components/Avatar.astro
@@ -3,10 +3,10 @@ import { Image } from "astro:assets";
 import thumbnail from "@images/proffer_jacob.jpg";
 ---
 
-<figure
-  class="bg-dark-blue p-3 border-black border-l-highlight border-t-highlight border"
->
-  <div class="h-full bg-mid-blue p-3 border-black border">
+<figure>
+  <div
+    class="h-full bg-mid-blue p-3 border-black border border-t-highlight border-l-highlight"
+  >
     <div class="relative border-black border max-md:aspect-video">
       <div
         class="absolute h-full w-full animate-pulse outline-4 outline-light-blue -outline-offset-4 opacity-75"

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -18,11 +18,7 @@ const { headline } = Astro.props;
       )
     }
   </div>
-  <div class="p-3">
-    <div
-      class="p-3 bg-mid-blue border border-black border-l-highlight border-t-highlight"
-    >
-      <slot />
-    </div>
+  <div class="p-3 bg-mid-blue">
+    <slot />
   </div>
 </Section>

--- a/src/components/Project.astro
+++ b/src/components/Project.astro
@@ -48,7 +48,7 @@ const {
       tags && (
         <ul class="flex gap-2">
           {tags.map((tag: string) => (
-            <li class="px-3 text-light-blue bg-dark-blue border-black border">
+            <li class="px-3 text-light-blue bg-dark-blue border-black border border-t-highlight border-l-highlight">
               {tag}
             </li>
           ))}

--- a/src/components/ProjectGrid.astro
+++ b/src/components/ProjectGrid.astro
@@ -55,7 +55,7 @@ const projects = [
 
 <Section>
   <SecondaryHeadline text={headline} />
-  <ol class="m-3 border border-black border-l-highlight border-t-highlight">
+  <ol>
     {
       projects.map((post: any, index: number) => (
         <li class={index > 0 ? "border-t-1 border-black" : ""}>


### PR DESCRIPTION
This pull request includes multiple changes to the styling of components in the project. The main focus is on simplifying and standardizing the CSS classes used for borders and padding across different components.

Styling updates:

* [`src/components/AboutSection.astro`](diffhunk://#diff-2706e1230a3c5ef51d74a993b1e985b15e41a98c68c3e508b7227766a3d67e20L15-R15): Simplified the `div` class by removing redundant border classes.
* [`src/components/Avatar.astro`](diffhunk://#diff-e75c0de83a927f433fb00673e1d0bac746662d0d7c504020cfec3e60d3d37fb6L6-L9): Adjusted the `figure` and `div` classes to standardize border and padding styles.
* [`src/components/Hero.astro`](diffhunk://#diff-289237df7e7f2ebc1fa52e3aabba5f9a6599c1e53067fbf127b9d3a6b8943ab0L21-L27): Streamlined the `div` class by removing unnecessary border classes.
* [`src/components/Project.astro`](diffhunk://#diff-f9d4051bfb0878b3bbc44ca100db9917e9c01ce387024f91d7c3c9c49a008770L51-R51): Added border highlight classes to the `li` elements within the tags list for consistency.
* [`src/components/ProjectGrid.astro`](diffhunk://#diff-e28c13810532667cd8e4a1b3f2d2b4f14a1fc4805e37887cd4b1a2c9c644ff20L58-R58): Removed redundant border classes from the `ol` element.