### PR TITLE
Refactor Image loading attribute value handling

### DIFF
--- a/src/components/Project.astro
+++ b/src/components/Project.astro
@@ -5,22 +5,14 @@ import TertiaryHeadline from "./TertiaryHeadline.astro";
 interface Props {
   thumbnail: ImageMetadata;
   thumbnailAlt: string;
-  lazyLoaded: boolean;
   headline: string;
   description?: string;
   url: string;
   tags?: Array<string>;
 }
 
-const {
-  thumbnail,
-  thumbnailAlt,
-  lazyLoaded,
-  headline,
-  description,
-  url,
-  tags,
-} = Astro.props;
+const { thumbnail, thumbnailAlt, headline, description, url, tags } =
+  Astro.props;
 ---
 
 <a
@@ -37,7 +29,8 @@ const {
           alt={thumbnailAlt}
           widths={[297, 689, 294]}
           sizes="(max-width: 376px) 297px, (min-width: 376px) and (max-width: 767px) 689px, (min-width: 768px) 294px"
-          loading={lazyLoaded ? "lazy" : "eager"}
+          loading="lazy"
+          quality="mid"
           data-image
         />
       </div>
@@ -59,3 +52,21 @@ const {
     }
   </div>
 </a>
+
+<script>
+  const dynamicImages = document.querySelectorAll("[data-image]");
+
+  const observer = new IntersectionObserver((entries, observer) => {
+    entries.forEach((entry) => {
+      const image = entry.target;
+
+      if (entry.isIntersecting) {
+        // Switch to eager loading for images in the viewport
+        image.setAttribute("loading", "eager");
+        observer.unobserve(image);
+      }
+    });
+  });
+
+  dynamicImages.forEach((image) => observer.observe(image));
+</script>

--- a/src/components/ProjectGrid.astro
+++ b/src/components/ProjectGrid.astro
@@ -66,7 +66,6 @@ const projects = [
             tags={post.tags}
             thumbnail={post.thumbnail}
             thumbnailAlt={post.thumbnailAlt ?? ""}
-            lazyLoaded={index === 0 || index === 1 ? false : true}
           />
         </li>
       ))


### PR DESCRIPTION
Closes #70 

This pull request focuses on improving the image loading strategy and simplifying the `Project.astro` component by removing the `lazyLoaded` prop. The most important changes include removing the `lazyLoaded` prop from various places, setting the image loading attribute to "lazy" by default, and adding an IntersectionObserver to dynamically switch the loading attribute to "eager" when images enter the viewport.

Changes to image loading strategy:

* [`src/components/Project.astro`](diffhunk://#diff-f9d4051bfb0878b3bbc44ca100db9917e9c01ce387024f91d7c3c9c49a008770L8-R15): Removed `lazyLoaded` prop from the `Props` interface and its usage within the component.
* [`src/components/Project.astro`](diffhunk://#diff-f9d4051bfb0878b3bbc44ca100db9917e9c01ce387024f91d7c3c9c49a008770L40-R33): Set the image loading attribute to "lazy" by default and added a `quality` attribute with the value "mid".
* [`src/components/Project.astro`](diffhunk://#diff-f9d4051bfb0878b3bbc44ca100db9917e9c01ce387024f91d7c3c9c49a008770R55-R72): Added an IntersectionObserver to switch the image loading attribute to "eager" when images enter the viewport.

Simplification of `Project.astro` component:

* [`src/components/ProjectGrid.astro`](diffhunk://#diff-e28c13810532667cd8e4a1b3f2d2b4f14a1fc4805e37887cd4b1a2c9c644ff20L69): Removed the `lazyLoaded` prop from the `Project` component instances.