### PR TITLE
Remove ClientRouter component from BaseLayout

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,7 +1,6 @@
 ---
 import "@fontsource-variable/fira-code";
 import firaCode from "@fontsource-variable/fira-code/files/fira-code-latin-wght-normal.woff2";
-import { ClientRouter } from "astro:transitions";
 import "@styles/global.css";
 import SiteSEO from "@components/SiteSEO.astro";
 import Container from "@components/Container.astro";
@@ -57,7 +56,6 @@ const { pageTitle, pageDescription } = Astro.props;
       href={firaCode}
       crossorigin="anonymous"
     />
-    <ClientRouter />
   </head>
   <body class="mx-auto w-full leading-8 font-normal text-white bg-dark">
     <Container>
@@ -65,7 +63,7 @@ const { pageTitle, pageDescription } = Astro.props;
         class="grid gap-3 p-3 m-3 bg-light md:gap-6 md:p-6 md:m-6 border border-black border-t-highlight border-l-highlight"
       >
         <Header />
-        <main id="content" transition:name="root" transition:animate="fade">
+        <main id="content">
           <slot />
         </main>
         <Footer />


### PR DESCRIPTION
This pull request includes changes to the `src/layouts/BaseLayout.astro` file, primarily focused on removing the `ClientRouter` import and its usage in the layout. These changes simplify the layout by removing unnecessary client-side routing transitions.

Layout simplification:

* [`src/layouts/BaseLayout.astro`](diffhunk://#diff-621c0d4e1d798274214c5a1d9218138167506a88dcdace8c2bb980d6fb10b08bL4): Removed the import of `ClientRouter` from `astro:transitions` as well as its usage in the `main` element to simplify the layout. [[1]](diffhunk://#diff-621c0d4e1d798274214c5a1d9218138167506a88dcdace8c2bb980d6fb10b08bL4) [[2]](diffhunk://#diff-621c0d4e1d798274214c5a1d9218138167506a88dcdace8c2bb980d6fb10b08bL60-R66)