### PR TITLE
Add new experience entry for Elegant Seagulls

### DIFF
--- a/src/components/Experience.astro
+++ b/src/components/Experience.astro
@@ -5,12 +5,22 @@ import TertiaryHeadline from "@components/TertiaryHeadline.astro";
 
 const experienceItems = [
   {
+    company: "Elegant Seagulls",
+    positions: [
+      {
+        position: "Senior UI Developer",
+        startDate: "2025-07",
+        endDate: "",
+      },
+    ],
+  },
+  {
     company: "Sullivan",
     positions: [
       {
         position: "Developer",
         startDate: "2025-01",
-        endDate: "",
+        endDate: "2025-07",
       },
     ],
   },


### PR DESCRIPTION
This pull request updates the `experienceItems` array in `src/components/Experience.astro` to reflect new professional experience and corrects an end date for an existing entry.

Updates to professional experience:

* Added a new entry for "Elegant Seagulls" with the position of "Senior UI Developer" starting in July 2025.
* Updated the "Sullivan" entry to include an end date of July 2025 for the "Developer" position.