### PR TITLE
refactor: remove unnecessary role attributes from DateItem and BaseLayout components

### DIFF
--- a/src/components/DateItem.astro
+++ b/src/components/DateItem.astro
@@ -13,7 +13,6 @@ const { type, title, startDate, endDate } = Astro.props;
 
 <div
   class="flex flex-col gap-1 items-start justify-between p-3 bg-dark-blue border border-black border-t-highlight border-l-highlight max-md:flex-col max-md:items-start"
-  role="group"
   aria-label={type}
 >
   <h4 class="text-light-blue text-balance leading-6">{title}</h4>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -18,7 +18,6 @@ const { pageTitle, pageDescription } = Astro.props;
 
 <html lang="en">
   <head>
-    <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link
       rel="apple-touch-icon"


### PR DESCRIPTION
This pull request includes minor updates to improve accessibility and HTML standards compliance. Specifically, it removes an unused `role` attribute from the `DateItem.astro` component and eliminates a redundant `meta charset` tag from the `BaseLayout.astro` layout.

- Accessibility and HTML cleanup:
  * Removed the unnecessary `role="group"` attribute from the main container in `DateItem.astro` to simplify the markup and avoid redundant roles.
  * Removed the redundant `<meta charset="utf-8" />` tag from the `BaseLayout.astro` layout, as it may already be set elsewhere or is not required in this context.