### PR TITLE
refactor: remove aria-label attribute from DateItem component

### DIFF
--- a/src/components/DateItem.astro
+++ b/src/components/DateItem.astro
@@ -13,7 +13,6 @@ const { type, title, startDate, endDate } = Astro.props;
 
 <div
   class="flex flex-col gap-1 items-start justify-between p-3 bg-dark-blue border border-black border-t-highlight border-l-highlight max-md:flex-col max-md:items-start"
-  aria-label={type}
 >
   <h4 class="text-light-blue text-balance leading-6">{title}</h4>
   <div class="flex flex-wrap items-center gap-1">


### PR DESCRIPTION
This pull request makes a minor update to the `DateItem.astro` component by removing the `aria-label` attribute from the main container `div`. This change simplifies the markup and may improve accessibility by preventing redundant or unnecessary ARIA labeling.