### PR TITLE
feat: add loading overlay animation

### DIFF
--- a/src/components/Avatar.astro
+++ b/src/components/Avatar.astro
@@ -3,7 +3,7 @@ import { Image } from "astro:assets";
 import thumbnail from "@images/proffer_jacob.jpg";
 ---
 
-<figure>
+<figure class="avatar-container">
   <div
     class="h-full bg-linear-to-t from-dark-blue to-mid-blue p-3 border-black border border-t-highlight border-l-highlight"
   >
@@ -13,14 +13,32 @@ import thumbnail from "@images/proffer_jacob.jpg";
       >
       </div>
       <Image
-        class="w-full h-full object-contain"
+        class="avatar-image w-full h-full object-contain"
         src={thumbnail}
         alt=""
         widths={[144, 197, thumbnail.width]}
         sizes={`(max-width: 767px) 300px, (min-width: 768px) 197px, ${thumbnail.width}px`}
         quality="mid"
         loading="eager"
+        data-animate
       />
     </div>
   </div>
 </figure>
+
+<script>
+  import { animate, spring } from "motion";
+
+  // Blur-to-focus animation with slight scale
+  const avatar = document.querySelector(".avatar-image");
+  if (avatar) {
+    animate(
+      avatar,
+      {
+        filter: ["blur(20px)", "blur(0px)"],
+        opacity: [0, 1],
+      } as any,
+      { duration: 1, easing: spring() } as any,
+    );
+  }
+</script>

--- a/src/components/Avatar.astro
+++ b/src/components/Avatar.astro
@@ -3,7 +3,7 @@ import { Image } from "astro:assets";
 import thumbnail from "@images/proffer_jacob.jpg";
 ---
 
-<figure class="avatar-container">
+<figure>
   <div
     class="h-full bg-linear-to-t from-dark-blue to-mid-blue p-3 border-black border border-t-highlight border-l-highlight"
   >
@@ -13,32 +13,14 @@ import thumbnail from "@images/proffer_jacob.jpg";
       >
       </div>
       <Image
-        class="avatar-image w-full h-full object-contain"
+        class="w-full h-full object-contain"
         src={thumbnail}
         alt=""
         widths={[144, 197, thumbnail.width]}
         sizes={`(max-width: 767px) 300px, (min-width: 768px) 197px, ${thumbnail.width}px`}
         quality="mid"
         loading="eager"
-        data-animate
       />
     </div>
   </div>
 </figure>
-
-<script>
-  import { animate, spring } from "motion";
-
-  // Blur-to-focus animation with slight scale
-  const avatar = document.querySelector(".avatar-image");
-  if (avatar) {
-    animate(
-      avatar,
-      {
-        filter: ["blur(20px)", "blur(0px)"],
-        opacity: [0, 1],
-      } as any,
-      { duration: 1, easing: spring() } as any,
-    );
-  }
-</script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -68,6 +68,15 @@ const { pageTitle, pageDescription } = Astro.props;
     </noscript>
   </head>
   <body class="mx-auto w-full leading-8 font-normal text-white bg-dark">
+    <!-- Loading overlay -->
+    <div
+      id="loading-overlay"
+      class="fixed inset-0 z-50 bg-dark"
+      style="clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%);"
+      aria-hidden="true"
+    >
+    </div>
+
     <Container>
       <div
         class="grid gap-3 p-3 m-3 bg-light md:gap-6 md:p-6 md:m-6 border border-black border-t-highlight border-l-highlight"
@@ -79,5 +88,30 @@ const { pageTitle, pageDescription } = Astro.props;
         <Footer />
       </div>
     </Container>
+
+    <script>
+      import { animate } from "motion";
+
+      const overlay = document.getElementById("loading-overlay");
+
+      if (overlay) {
+        // Animate from full screen sliding down, revealing content from top to bottom
+        animate(
+          overlay,
+          {
+            clipPath: [
+              "polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%)", // Full screen coverage
+              "polygon(0% 100%, 100% 100%, 100% 100%, 0% 100%)", // Collapsed at bottom
+            ],
+          } as any,
+          { duration: 0.8, easing: [0.22, 1, 0.36, 1], delay: 0.2 } as any,
+        ).finished.then(() => {
+          // Remove overlay after animation completes
+          overlay.remove();
+        });
+      }
+    </script>
+
+
   </body>
 </html>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -64,6 +64,10 @@ const { pageTitle, pageDescription } = Astro.props;
         [data-animate] {
           opacity: 1 !important;
         }
+        /* Hide loading overlay when JavaScript is disabled */
+        #loading-overlay {
+          display: none !important;
+        }
       </style>
     </noscript>
   </head>
@@ -72,7 +76,6 @@ const { pageTitle, pageDescription } = Astro.props;
     <div
       id="loading-overlay"
       class="fixed inset-0 z-50 bg-dark"
-      style="clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%);"
       aria-hidden="true"
     >
     </div>
@@ -89,26 +92,29 @@ const { pageTitle, pageDescription } = Astro.props;
       </div>
     </Container>
 
-    <script>
-      import { animate } from "motion";
-
+    <script lang="ts">
       const overlay = document.getElementById("loading-overlay");
 
       if (overlay) {
-        // Animate from full screen sliding down, revealing content from top to bottom
-        animate(
-          overlay,
-          {
-            clipPath: [
-              "polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%)", // Full screen coverage
-              "polygon(0% 100%, 100% 100%, 100% 100%, 0% 100%)", // Collapsed at bottom
-            ],
-          } as any,
-          { duration: 0.8, easing: [0.22, 1, 0.36, 1], delay: 0.2 } as any,
-        ).finished.then(() => {
-          // Remove overlay after animation completes
+        // Check if user prefers reduced motion
+        const prefersReducedMotion = window.matchMedia(
+          "(prefers-reduced-motion: reduce)",
+        ).matches;
+
+        if (prefersReducedMotion) {
+          // Remove overlay immediately without animation
           overlay.remove();
-        });
+        } else {
+          // Fade out the overlay
+          setTimeout(() => {
+            overlay.style.opacity = "0";
+            overlay.style.transition = "opacity 0.6s ease-out";
+
+            overlay.addEventListener("transitionend", () => {
+              overlay.remove();
+            });
+          }, 200);
+        }
       }
     </script>
 


### PR DESCRIPTION
This pull request enhances the user experience by introducing a loading overlay that appears while the page is loading and then fades out smoothly once the content is ready. The overlay is also accessible, respecting users' system preferences for reduced motion and ensuring it is hidden if JavaScript is disabled.

User experience improvements:

* Added a `#loading-overlay` div to display a full-screen overlay while the page loads, improving perceived performance and visual feedback.
* Implemented a script that fades out and removes the overlay after the page loads, with instant removal for users who prefer reduced motion, ensuring accessibility and respect for user preferences.
* Ensured the overlay is hidden when JavaScript is disabled by adding a CSS rule within a `<noscript>` block, maintaining usability for all users.